### PR TITLE
add link to js13k-requirejs template

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
 	<li><a href="https://github.com/ooflorent/js13k-boilerplate">js13k-boilerplate</a> - js13kGames boilerplate</li>
 	<li><a href="http://jallegro.sos.gd/">jAllegro</a> - a JavaScript port of a game programming library</li>
 	<li><a href="https://github.com/lucaspenney/js13k-toolkit">js13k-toolkit</a> - starter repository for js13kGames, a set of tools for developing a JS game and keeping it under 13kb</li>
+	<li><a href="https://github.com/spmurrayzzz/js13k-requirejs">js13k-requirejs</a> - require.js-powered application template with build tools</li>
 </ul>
 
 <h3>Sound and music</h3>
@@ -86,7 +87,7 @@
 	<li><a href="https://hacks.mozilla.org/2013/09/getting-started-with-html5-game-development/">Getting started with HTML5 game development</a></li>
 	<li><a href="http://codeincomplete.com/posts/2013/5/27/tiny_platformer/">Tiny platformer</a></li>
 	<li><a href="http://www.playfuljs.com/a-first-person-engine-in-265-lines/">A first-person engine in 265 lines</a></li>
-</ul>  
+</ul>
 
 <h3>Blog posts and post mortems</h3>
 <ul>


### PR DESCRIPTION
This PR adds a link to a boilerplate repo I've built that does a few things:

https://github.com/spmurrayzzz/js13k-requirejs

- Adds an opinionated application structure using `requirejs`
- Adds a few base abstractions including:
  - Classical inheritance 
  - Event Emitter pattern
  - Game loop
- Concats, minifies, and inlines JS/CSS into a single `index.html` build artifact
- Compresses the build artifact into a single `index.html.zip`

Build tools: `grunt`, `adm-zip`