### PR TITLE
Add post-mortem for The Core by Matthew McCord

### DIFF
--- a/index.html
+++ b/index.html
@@ -252,6 +252,7 @@
 				<li><a href="https://shreyasminocha.me/blog/js13k-2018-postmortem/">WiFiHunt</a> by Shreyas Minocha</li>
 				<li><a href="https://timmykokke.com/post/2018-09-18-js13kgames-2018-postmortem/">Lasergrid</a> by Timmy Kokke</li>
 				<li><a href="http://jack-oatley.com/index.php?post=blog/2018_09_17_Exo.html">Exo</a> by Jack Oatley</li>
+				<li><a href="https://github.com/mccordgh/the_line_js13kgames_2018/blob/master/README.md">The Core</a> by Matthew McCord</li>
 			</ul>
 		</li>
 	</ul>


### PR DESCRIPTION
Adds the html to link to the post-mortem for "The Core" js13kgames 2018 entry by Matthew McCord