### PR TITLE
Added Canvas-Txt

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,6 +98,7 @@
 		<li><a href="https://github.com/xem/twemoji-webfont">Twemoji-webfont</a> - helps you live-load an Emoji webfont for any browser, after asking the user if he/she's okay</li>
 		<li><a href="https://codepen.io/xem/pen/OoXpmM?editors=1000">SVGenerator</a> - a dynamic SVG generator with custom colors</li>
 		<li><a href="https://xem.github.io/CSS3D/">CSS3D</a> - The shortest way to write CSS3D cubes, pyramids and sprites (<a href="https://github.com/xem/CSS3D/blob/gh-pages/index.html">source code</a>)</li>
+		<li><a href="http://canvas-txt.geongeorge.com/">Canvas-Txt</a> - The better way to print multiline text on HTML5 canvas with auto line breaks and alignments (<a href="https://github.com/geongeorge/Canvas-Txt">source code</a>)</li>
 	</ul>
 
 	<h3 id="mini">Minification</h3>


### PR DESCRIPTION
Added **Canvas-Txt** library. 
https://github.com/geongeorge/Canvas-Txt

Usage:
To render text content into HTML5 Canvas with better line breaks and alignments