### PR TITLE
Add npm version of TypeScirpt Webpack Starter Template, clean up some HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,365 +1,344 @@
 <!DOCTYPE html>
 <html>
-<head>
-	<meta charset="utf-8">
-	<title>js13kGames Resources</title>
-	<meta name="author" content="end3r">	
-	<meta name="description" content="List of useful tools, materials, and tutorials for creating a js13kGames entry, and post-mortems from already created games." />
-	<meta name="monetization" content="$coil.xrptipbot.com/-CgHpYu7SfeoDmHVugOfrw" />	
-	<link rel="shortcut icon" href="favicon.png">
-	<link rel="stylesheet" href="style.css">
-    <link href="https://fonts.googleapis.com/css?family=Graduate" rel="stylesheet">
-	<meta property="og:url" content="https://js13kgames.github.io/resources/" />
-	<meta property="og:type" content="website" />
-	<meta property="og:title" content="js13kGames Resources"/>
-	<meta property="og:description" content="List of useful tools, materials, and tutorials for creating a js13kGames entry, and post-mortems from already created games."/>
-	<meta property="og:image" content="https://js13kgames.github.io/resources/img/js13kgames-banner.png"/>
-	<meta name="twitter:card" content="summary_large_image">
-	<meta name="twitter:site" content="js13kgames">
-	<meta name="twitter:creator" content="end3r">
-	<meta name="twitter:title" content="js13kGames Resources">
-	<meta name="twitter:description" content="List of useful tools, materials, and tutorials for creating a js13kGames entry, and post-mortems from already created games.">
-	<meta name="twitter:image" content="https://js13kgames.github.io/resources/img/js13kgames-banner.png">
-</head>
-<body>
-<header>
-	<nav>
-		<a href="https://js13kgames.com">js13kGames</a>
-		<ul>
-			<li><a href="https://2019.js13kgames.com">2019</a></li>
-			<li><a href="https://2018.js13kgames.com">2018</a></li>
-			<li><a href="https://2017.js13kgames.com">2017</a></li>
-			<li><a href="https://2016.js13kgames.com">2016</a></li>
-			<li><a href="https://2015.js13kgames.com">2015</a></li>
-			<li><a href="https://2014.js13kgames.com">2014</a></li>
-			<li><a href="https://2013.js13kgames.com">2013</a></li>
-			<li><a href="https://2012.js13kgames.com">2012</a></li>
-		</ul>
-	</nav>
-</header>
-
-<main>
-	<h1>js13kGames Resources</h1>
-	<p>
-		List of useful tools, materials, and tutorials for creating a js13kGames entry, and post-mortems from already created games. The items are in no particular order.
-		Please feel free to <strong>suggest additions or edits</strong> to the list either by <a href="https://github.com/js13kgames/resources/pulls">sending
-		a pull request</a> on GitHub or emailing them to <a href="mailto:contact@js13kgames.com">contact@js13kgames.com</a>.
-	</p>
-
-	<h3 id="engine">Micro game engines and boilerplates</h3>
-	<ul>
-		<li><a href="https://github.com/OttoRobba/ox">ox</a> - tiny 2D game framework for the web</li>
-		<li><a href="https://github.com/Gozala/selfish">Selfish</a> - class-free, pure prototypal inheritance</li>
-		<li><a href="https://github.com/michalbe/mibbu">Mibbu</a> - Javascript game microframework</li>
-		<li><a href="http://jallegro.sos.gd/">jAllegro</a> - JavaScript port of a game programming library</li>
-		<li><a href="https://github.com/geoffb/ocelot">Ocelot</a> - minimalist HTML5 2D game engine, Ocelot aims for simplicity and small filesize</li>
-		<li><a href="https://github.com/ooflorent/js13k-boilerplate">js13k-boilerplate</a> - js13kGames boilerplate</li>
-		<li><a href="https://github.com/shreyasminocha/js13k-boilerplate">JS13k Gulp workflow</a> - A gulp-powered workflow with source file minification, image optimization and zip generation</li>
-		<li><a href="https://github.com/lucaspenney/js13k-toolkit">js13k-toolkit</a> - starter repository for js13kGames, a set of tools for developing a JS game and keeping it under 13kb</li>
-		<li><a href="https://github.com/spmurrayzzz/js13k-requirejs">js13k-requirejs</a> - require.js-powered application template with build tools</li>
-		<li><a href="https://github.com/spmurrayzzz/js13k-rollup">js13k-rollup</a> - gulp/rollup.js powered template with support for ES2015 modules and build tools</li>
-		<li><a href="https://github.com/aymanfarhat/js13k-starter">js13k-starter</a> - sample js13k project structure, example and Gulp build process</li>
-		<li><a href="https://github.com/bitnenfer/tiny-canvas">Tiny-Canvas</a> - lightweight minimal implementation of a batched and stack matrix based Canvas with WebGL backend</li>
-		<li><a href="https://github.com/kittykatattack/ga">Ga</a> - tiny, cute and friendly system for making HTML5 games</li>
-		<li><a href="https://github.com/xem/platform-engine">platform-engine</a> - 2D platform engine that handles collisions, slopes, rotations, etc.</li>
-		<li><a href="https://github.com/voronianski-on-games/js13kGames-boilerplate">js13kGames-boilerplate</a> - includes game loop, utility functions and webpack config to package game with just one command</li>
-		<li><a href="https://github.com/sz-piotr/js13k-webpack-starter">js13k-webpack-starter</a> - build with a single command, dev server, es2015 support</li>
-		<li><a href="https://github.com/aerze/js13k-base">js13k-base</a> - simple commands, a server, and a sample game + framework</li>
-		<li><a href="https://github.com/mtmckenna/js13k-webpack-typescript-starter-party">js13k-webpack-typescript-starter-party</a> - starter Webpack project to transpile TypeScript, build, and zip your game<li>
-		<li><a href="https://github.com/mtmckenna/js13kgames-parcel-starter">js13kgames-parcel-starter</a> - starter repo to build, zip, and check the file size of your game with a single command</li>
-		<li><a href="https://github.com/xem/responsiveTouchGameFramework">responsiveTouchGameFramework</a> - responsive canvas game framework with unified mouse / tactile inputs</li>
-		<li><a href="https://twitter.com/MaximeEuziere/status/883044404453294080">Tweetwork</a> - a 140b canvas game framework</li>
-		<li><a href="https://straker.github.io/kontra/">Kontra</a> - a lightweight JavaScript gaming micro-library, optimized for js13kGames</li>
-		<li><a href="https://github.com/Rybar/js13k2017kit">JS13K 2017 Kit</a> - a pico-8 like graphics engine and game boilerplate</li>
-	        <li><a href="https://github.com/jonathan-vallet/js13k-starter">JS13K starter</a> - gulp starter watching changes, and tasks to compile, minify, inline, and zip you game for better optimization</li>
-	        <li><a href="https://github.com/kutuluk/js13k-ecs">js13k-ecs</a> - a 1kb entity component system, designed for js13k</li>
-	        <li><a href="https://github.com/kutuluk/js13k-2d">js13k-2d</a> - a &lt;2kb 2D WebGL renderer, designed for js13k</li>
-		<li><a href="https://github.com/lpagg/floppy">floppy</a> - a micro game engine for beginners</li>
-		<li><a href="https://github.com/xem/CSS3Dframework">CSS3Dframework</a> - a hackable ~1.7kb framework to display and animate CSS3D shapes</li>
-		<li><a href="https://twitter.com/MaximeEuziere/status/1157563570823081984">MiniDragAndDrop</a> - a DOM-based, easy-to-use drag&drop library for desktop and mobile browsers (639 bytes)</li>
-		<li><a href="https://github.com/xem/mini2Dphysics/">Mini2Dphysics</a> - a 1.5kb 2D physics engine. Just set the gravity, create Circles and Rectangles, and watch them fall and collide. (see index.html)</li>
-		<li><a href="https://jabo-bernardo.github.io/jabo-micro-game-engine/">Jabo Micro Game Engine</a> - lightweight and beginner friendly micro game engine</li>
-		<li><a href="https://github.com/swashvirus/craters.js">Craters.js mini game framework</a> - simple to use hackable framework, compact at ~2kb zipped leaving enough room for game logic</li>
-		<li><a href="https://twitter.com/MaximeEuziere/status/1257783623316656130">280 bytes responsive, hackable, mobile friendly game framework</a> with native arrow keys / WASD / ZQSD key inputs detection</li>
-	</ul>
-
-	<h3 id="sfx">Sound and music</h3>
-	<ul>
-		<li><a href="http://sb.bitsnbites.eu/">SoundBox</a> - an HTML5 synth music tracker</li>
-		<li><a href="https://github.com/mneubrand/jsfxr">jsfxr</a> - <a href="http://www.superflashbros.net/as3sfxr/">as3sfxr</a> synth port to JavaScript</li>
-		<li><a href="http://codepen.io/jackrugile/blog/arcade-audio-for-js13k-games">Arcade audio for js13kGames</a> - blog post about generating your own sound effects</li>
-		<li><a href="https://github.com/nicolas-van/sonant-x">Sonant-X</a> - small JavaScript synthesizer library</li>
-		<li><a href="http://www.cappel-nord.de/webaudio/">Web Audio API prototypes</a> - demos using the Web Audio API to synthesize audio in the browser</li>
-		<li><a href="https://github.com/kevincennis/TinyMusic">TinyMusic</a> - simple, lightweight music synth/sequencer in JavaScript using the Web Audio API</li>
-		<li><a href="https://github.com/xem/miniMusic">miniMusic</a> - draw a melody with your mouse, choose the tempo, volume and base note, then export it as a super short JS code</li>
-		<li><a href="https://www.google.com/logos/2017/fischinger/fischinger17.html">Google Music Creator</a> - a simple music creator by Google</li>
-		<li><a href="https://zzfx.3d2k.com">ZzFX</a> - Zuper Zmall Zeeded Zound Zynth</li>
-	</ul>
-
-	<h3 id="gfx">Artwork and fonts</h3>
-	<ul>
-		<li><a href="http://opengameart.org">OpenGameArt</a> - free graphics assets</li>
-		<li><a href="http://codepen.io/agares/pen/CtxuE/">Sprite generator</a> - 1 color sprite interpreter</li>
-		<li><a href="http://www.iquilezles.org/www/articles/voronoise/voronoise.htm">Voronoise</a> - procedural pattern generation</li>
-		<li><a href="https://github.com/download13/blockies">Blockies</a> - identicon generation</li>
-		<li><a href="http://pixelmap.amcharts.com/">Pixel map generator</a> - generate pixel maps</li>
-		<li><a href="http://www.pixenapp.com/">Pixen</a> - pixel art editor for Mac OS X</li>
-		<li><a href="http://compresspng.com/">CompressPNG</a> - compress PNGs online</li>
-		<li><a href="http://tinypng.com/">TinyPNG</a> - advanced lossy compression for PNG images that preserves full alpha transparency</li>
-		<li><a href="https://github.com/PaulBGD/PixelFont">Pixel Font</a> - tiny pixel font</li>
-		<li><a href="https://github.com/xem/js13k-graphics-editor">js13k-graphics-editor</a> - Draw with your mouse and export the result as a tiny JS snippet</li>
-		<li><a href="http://www.piskelapp.com/">Piskel</a> - Pixel Art and Animated Sprites</li>
-		<li><a href="http://www.aseprite.org/">aseprite</a> - animated sprite editor &amp; pixel art tool</li>
-		<li><a href="http://pyxeledit.com">Pyxel Edit</a> - is a pixel art editor designed to make it fun and easy to make tilesets, levels and animations</li>
-                <li><a href="https://xem.github.io/miniPixelFont/">mini pixel font</a> - Generate your pixel-art font with a few lines of JS</li>
-                <li><a href="https://github.com/madmarcel/js13k-mini-svg-editor">js13k mini-svg editor</a> - Create mini-svg graphics for your js13k game using a webbased editor</li>
-		<li><a href="https://github.com/xem/js13k-path">js13k-path</a> - draw polygons where every point is encoded on 1 ASCII char</li>
-		<li><a href="https://xem.github.io/miniPixelArt/">MiniPixelArt</a> - a 8-color pixel-art editor and exporter (pure JS, no PNG)</li>
-		<li><a href="https://github.com/xem/twemoji-webfont">Twemoji-webfont</a> - helps you live-load an Emoji webfont for any browser, after asking the user if he/she's okay</li>
-		<li><a href="https://codepen.io/xem/pen/OoXpmM?editors=1000">SVGenerator</a> - a dynamic SVG generator with custom colors</li>
-		<li><a href="https://xem.github.io/CSS3D/">CSS3D</a> - The shortest way to write CSS3D cubes, pyramids and sprites (<a href="https://github.com/xem/CSS3D/blob/gh-pages/index.html">source code</a>)</li>
-		<li><a href="http://canvas-txt.geongeorge.com/">Canvas-Txt</a> - The better way to print multiline text on HTML5 canvas with auto line breaks and alignments (<a href="https://github.com/geongeorge/Canvas-Txt">source code</a>)</li>
-		<li><a href="https://spritestack.io/">SpriteStack</a> - SpriteStack is a voxel editor suited for 2D artists featuring hand crafted retro renderer with animation support. It exports spritesheets, slices and vox models.</li>
-		<li><a href="https://github.com/darkwebdev/tinyfont.js">tinyfont.js</a> - Tiniest possible pixel font for your JS games (<700b zipped)!</li>
-		<li><a href="https://xem.github.io/emoji/">emoji</a> - a webfont that can be loaded from your entry to fix/complete the emoji that can be seen by all your future players</li>
-	</ul>
-
-	<h3 id="mini">Minification</h3>
-	<ul>
-		<li><a href="https://babeljs.io/repl">babeljs</a> - JS (ES2015/2016/2017) minifier based on Babili, choose your flavor in the "presets" dropdown</li>
-		<li><a href="http://dean.edwards.name/packer/">Packer</a> - JavaScript compressor</li>
-		<li><a href="http://javascript-minifier.com/">JavaScript Minifier</a> - minify your JavaScript</li>
-		<li><a href="https://github.com/Siorki/RegPack">RegPack</a> -  self-contained packer for size-constrained JS code</li>
-		<li><a href="http://closure-compiler.appspot.com/home">Closure Compiler</a> - compile your code</li>
-		<li><a href="https://github.com/mishoo/UglifyJS">UglifyJS</a> - JavaScript parser / mangler / compressor / beautifier library for NodeJS</li>
-		<li><a href="http://www.slideshare.net/DavidGoemans/extreme-javascript-minification">Extreme Javascript minification</a> - compression experiments</li>
-		<li><a href="http://www.advancemame.it/download">ADVZIP</a> - zip file optimizer / recompressor (can reduce a 13kb zip to 9~11kb)</li>
-		<li><a href="https://github.com/xem/miniMinifier/">miniMinifier</a> - tiny (but super efficient) HTML and CSS minifiers</li>
-		<li><a href="http://www.minifier.org/">Minify</a> - a JavaScript and CSS minifier</li>
-		<li><a href="https://jscompress.com/">JSCompress</a> - a compression tool for javascript</li>
-		<li><a href="https://github.com/codegolf/zpng">ZPNG Minifier</a> - in-browser jsExe</li>
-		<li><a href="https://xem.github.io/int2binary2html/">int2binary2html</a> - helps you to encode a long list of integers (0-255) in binary and embed it in your index.html</li>
-		<li><a href="https://xem.github.io/terser-online/">Terser-online</a> - a live version of the Terser ES6+ minifier, with extra compression options because every byte counts</li>
-	</ul>
-
-	<h3 id="aframe">WebXR resources</h3>
-	<ul>
-		<li><a href="https://aframe.io/docs/0.6.0/introduction/#getting-started">A-Frame Documentation</a> - introduciton to A-Frame</li>
-		<li><a href="https://aframevr-slack.herokuapp.com/">A-Frame Slack invitation</a> - ask questions here</li>
-		<li><a href="https://aframe.io/aframe-registry/">A-Frame Registry</a> - useful components</li>
-		<li><a href="https://github.com/aframevr/awesome-aframe">Awesome A-Frame</a> - many more A-Frame resources &amp; examples</li>
-		<li><a href="https://github.com/xem/gyro">Gyro.js</a> - harmonizes the gyroscope/accelerometer output across all mobile devices</li>
-		<li><a href="https://github.com/mguinea/js13k-aframe-boilerplate">js13k A-Frame Webpack boilerplate</a> - build with a single command, dev server, es2015 support, basic example</li>
-	</ul>
-
-	<h3 id="other">Other tools</h3>
-	<ul>
-		<li><a href="http://videogamena.me/">Video Game Name Generator</a> - generate a name for your game</li>
-		<li><a href="https://github.com/mrdoob/stats.js/">stats.js</a> - JavaScript performance monitor</li>
-		<li><a href="http://khan.github.io/live-editor/demos/simple/">Live Editor</a> - edit JavaScript code</li>
-		<li><a href="https://github.com/allouis/minivents">Minivents</a> - small event system for JavaScript</li>
-		<li><a href="https://gist.github.com/xem/99930986c5333125a13b0ea50600391f">Maths and trigonometry cheat sheet for 2D games</a></li>
-		<li><a href="https://github.com/js13kGames/js13kserver">js13kserver</a> - sandboxed JavaScript game server</li>
-		<li><a href="https://github.com/xem/js13k-level-editor">js13k-level-editor</a> - 1kb 2D map editor that you can use for your game (or include in your game!)</li>
-		<li><a href="https://github.com/xem/3D-level-editor">3D-level-editor</a> - CSS3D map editor with customizable 3D shapes and 2D sprites</li>
-		<li><a href="https://github.com/xenohunter/timestore">timestore</a> - library to manage multiple timers inside separate contexts</li>
-		<li><a href="https://github.com/stasm/innerself">innerself</a> - a React/Redux-like view and state management for your game's UI, in less than 400 bytes</li>
-	</ul>
-
-	<h3 id="tuts">Tutorials</h3>
-	<ul>
-		<li><a href="http://gamedevelopment.tutsplus.com/articles/how-to-minify-your-html5-game-for-the-js13kgames-competition--cms-21883">How to minify your HTML5 game for the js13kGames competition</a></li>
-		<li><a href="http://www.gamedevacademy.org/js13kgames-tutorial/">js13kGames tutorial - How to make a text game with HTML5</a></li>
-		<li><a href="https://hacks.mozilla.org/2013/09/getting-started-with-html5-game-development/">Getting started with HTML5 game development</a></li>
-		<li><a href="http://codeincomplete.com/posts/2013/5/27/tiny_platformer/">Tiny platformer</a></li>
-		<li><a href="http://www.playfuljs.com/a-first-person-engine-in-265-lines/">A first-person engine in 265 lines</a></li>
-		<li><a href="http://ojdon.github.io/blog/HTML5-Game-Development-Gulp-Workflow">HTML5 game development Gulp workflow</a></li>
-		<li><a href="https://gist.github.com/xem/99930986c5333125a13b0ea50600391f">Trigonometry cheat sheet</a></li>
-		<li><a href="https://gamedevacademy.org/js13kgames-tutorial-video-series/">js13kGames tutorial video series by Zenva Academy</a> - create a Frogger game in 13kb or less</li>
-		<li><a href="https:https://xem.github.io/articles/jsgamesinputs.html">How to support arrow keys, WASD and ZQSD keyboard inputs in just 160b of JS</a></li>
-		<li><a href="https://xem.github.io/articles/css3dgames.html">How to make games with CSS3D</a></li>
-		<li><a href="https://aframe.io/aframe-school/">A-Frame School</a></li>
-		<li><a href="https://medium.com/web-maker/making-asteroids-with-kontra-js-and-web-maker-95559d39b45f">Making Asteroids with Kontra.js and Web Maker</a> - handy tutorial from Steven Lambert, the author of Kontra.js</li>
-		<li><a href="https://craiky.github.io/tutorial/">Procedurally Generated Dungeon Tutorial</a></li>
-		<li><a href="http://7tonshark.com/2018-09-16-web-audio-part-1/">Creating simple music using the Web Audio API</a></li>
-		<li><a href="https://xem.github.io/articles/webgl-guide.html">WebGL guide</a></li>
-	</ul>
-
-	<h3 id="vids">Videos and audio</h3>
-	<ul>
-		<li><a href="https://www.youtube.com/playlist?list=PLYKU1lvSF85cletut9NULJwgEtN01TYWm">Jupi Plays Indie Games 2014</a> - YouTube playlist with Jupiter Hadley playing all the games from the 2014 edition</li>
-		<li><a href="https://www.youtube.com/playlist?list=PL94Kxubp5fYe3XwC3rIeybFUhIkeuhJym">Let's play vids for js13k 2015</a> - YouTube playlist for 2015 entries by Keith Karnage</li>
-		<li><a href="https://www.youtube.com/playlist?list=PLYKU1lvSF85czCO1G2UgwvxRpzGw8P2Bn">Jupi Plays Indie Games 2015</a> - YouTube playlist for 2015 entries by Jupiter Hadley</li>
-		<li><a href="https://www.youtube.com/playlist?list=PLYKU1lvSF85e_jRg9g12GhpATCW1ETrb1">Jupi Plays Indie Games 2016</a> - YouTube playlist for 2016 entries by Jupiter Hadley</li>
-		<li><a href="https://www.youtube.com/watch?v=8gSTuXrFyIc">JS13K 2017 games compilation</a> - YouTube video by Agar3s</li>
-		<li><a href="https://www.youtube.com/playlist?list=PLYKU1lvSF85c4UPV3J1onIf-Qv13GJ7H8">Jupi Plays Indie Games 2017</a> - YouTube playlist for 2017 entries by Jupiter Hadley</li>
-		<li><a href="https://soundcloud.com/the-game-developers-radio/game-design-daily-068-game-dev-article-round-up-part-02">The Game Developers Radio: Game Design Daily 068</a> - game dev article round up part 02 on SoundCloud</li>
-		<li><a href="https://www.youtube.com/watch?v=RdOram609vU">How to squeeze a HTML5 game in 13 kB?</a> - Andrzej Mazur's introductory speech. Subtitles by B0dz1o</li>
-		<li><a href="https://edgeguard.podbean.com/e/111-js13k/">Edge Guard podcast #111 about js13kGames 2019</a></li>
-	</ul>
-
-	<h3 id="posts">Blog posts and post mortems</h3>
-	<ul>
-		<li><a href="https://gabor.heja.hu/blog/2018/04/25/untitled13/">untitled13</a> by Gabor Heja</li>
-		<li class="posts" id="posts2015"><strong>2015 post-mortems:</strong>
+	<head>
+		<meta charset="utf-8">
+		<title>js13kGames Resources</title>
+		<meta name="author" content="end3r">
+		<meta name="description" content="List of useful tools, materials, and tutorials for creating a js13kGames entry, and post-mortems from already created games." />
+		<meta name="monetization" content="$coil.xrptipbot.com/-CgHpYu7SfeoDmHVugOfrw" />
+		<link rel="shortcut icon" href="favicon.png">
+		<link rel="stylesheet" href="style.css">
+		<link href="https://fonts.googleapis.com/css?family=Graduate" rel="stylesheet">
+		<meta property="og:url" content="https://js13kgames.github.io/resources/" />
+		<meta property="og:type" content="website" />
+		<meta property="og:title" content="js13kGames Resources" />
+		<meta property="og:description" content="List of useful tools, materials, and tutorials for creating a js13kGames entry, and post-mortems from already created games." />
+		<meta property="og:image" content="https://js13kgames.github.io/resources/img/js13kgames-banner.png" />
+		<meta name="twitter:card" content="summary_large_image">
+		<meta name="twitter:site" content="js13kgames">
+		<meta name="twitter:creator" content="end3r">
+		<meta name="twitter:title" content="js13kGames Resources">
+		<meta name="twitter:description" content="List of useful tools, materials, and tutorials for creating a js13kGames entry, and post-mortems from already created games.">
+		<meta name="twitter:image" content="https://js13kgames.github.io/resources/img/js13kgames-banner.png">
+	</head>
+	<body>
+		<header>
+			<nav> <a href="https://js13kgames.com">js13kGames</a>
+				<ul>
+					<li> <a href="https://2019.js13kgames.com">2019</a> </li>
+					<li> <a href="https://2018.js13kgames.com">2018</a> </li>
+					<li> <a href="https://2017.js13kgames.com">2017</a> </li>
+					<li> <a href="https://2016.js13kgames.com">2016</a> </li>
+					<li> <a href="https://2015.js13kgames.com">2015</a> </li>
+					<li> <a href="https://2014.js13kgames.com">2014</a> </li>
+					<li> <a href="https://2013.js13kgames.com">2013</a> </li>
+					<li> <a href="https://2012.js13kgames.com">2012</a> </li>
+				</ul>
+			</nav>
+		</header>
+		<main>
+			<h1>js13kGames Resources</h1>
+			<p> List of useful tools, materials, and tutorials for creating a js13kGames entry, and post-mortems from already created games. The items are in no particular order. Please feel free to <strong>suggest additions or edits</strong> to the list either by <a href="https://github.com/js13kgames/resources/pulls">sending a pull request</a> on GitHub or emailing them to <a href="mailto:contact@js13kgames.com">contact@js13kgames.com</a>. </p>
+			<h3 id="engine">Micro game engines and boilerplates</h3>
 			<ul>
-				<li><a href="https://brosteins.com/2015/09/13/js13kgames-2015/">Nomis</a> by Nick Branstein</li>
-				<li><a href="https://github.com/EduardoLopes/js13kgames-2015/blob/master/README.md">Tiny Stealth</a> by Eduardo Lopes</li>
-				<li><a href="http://jamesswright.co.uk/blog/1442177-time-worm-js13kgames-entry">Time Worm</a> by James Wright</li>
-				<li><a href="http://blog.kodewerx.org/2015/09/its-lovely-day-for-postmortem.html">It's a Lovely Day for a Drive</a> by Jay Oster</li>
-				<li><a href="http://bitowl.net/raw-space/">Raw | space</a> by Bitowl</li>
-				<li><a href="https://xem.github.io/articles/js13k15.html">GeoQuiz</a> by Maxime Euzière</li>
-				<li><a href="https://github.com/gre/behind-asteroids/blob/master/README.md">Behind Asteroids — The Dark Side</a> by Gaëtan Renaudeau</li>
-				<li><a href="http://giddyplanet.com/2015/09/galactic-backfire-a-retrospective-of-my-js13k-entry/">Galactic Backfire</a> by Rene Hangstrup Møller</li>
-				<li><a href="https://ash.ms/blog/2015-09-17/road-blocks">Road Blocks</a> by Ash Kyd</li>
-				<li><a href="https://github.com/morazor/TCM/wiki">The Cursed Mirror</a> by Marco Emiliozzi</li>
-				<li><a href="https://github.com/madmaw/LD33/blob/master/README.md">Poust</a> by Chris Glover</li>
-				<li><a href="https://github.com/MakeshiftMitten/bombsaway/blob/master/README.md">Bombs Away</a> by Makeshift Mitten</li>
-				<li><a href="http://www.loganfranken.com/blog/1226/my-second-js13k/">ParaTec Systems</a> by Logan Franken</li>
-				<li><a href="https://gabor.heja.hu/blog/2018/05/16/bokosan-a-reverse-sokoban/">Bokosan</a> by Gabor Heja</li>
+				<li> <a href="https://github.com/OttoRobba/ox">ox</a> - tiny 2D game framework for the web </li>
+				<li> <a href="https://github.com/Gozala/selfish">Selfish</a> - class-free, pure prototypal inheritance </li>
+				<li> <a href="https://github.com/michalbe/mibbu">Mibbu</a> - Javascript game microframework </li>
+				<li> <a href="http://jallegro.sos.gd/">jAllegro</a> - JavaScript port of a game programming library </li>
+				<li> <a href="https://github.com/geoffb/ocelot">Ocelot</a> - minimalist HTML5 2D game engine, Ocelot aims for simplicity and small filesize </li>
+				<li> <a href="https://github.com/ooflorent/js13k-boilerplate">js13k-boilerplate</a> - js13kGames boilerplate </li>
+				<li> <a href="https://github.com/shreyasminocha/js13k-boilerplate">JS13k Gulp workflow</a> - A gulp-powered workflow with source file minification, image optimization and zip generation </li>
+				<li> <a href="https://github.com/lucaspenney/js13k-toolkit">js13k-toolkit</a> - starter repository for js13kGames, a set of tools for developing a JS game and keeping it under 13kb </li>
+				<li> <a href="https://github.com/spmurrayzzz/js13k-requirejs">js13k-requirejs</a> - require.js-powered application template with build tools </li>
+				<li> <a href="https://github.com/spmurrayzzz/js13k-rollup">js13k-rollup</a> - gulp/rollup.js powered template with support for ES2015 modules and build tools </li>
+				<li> <a href="https://github.com/aymanfarhat/js13k-starter">js13k-starter</a> - sample js13k project structure, example and Gulp build process </li>
+				<li> <a href="https://github.com/bitnenfer/tiny-canvas">Tiny-Canvas</a> - lightweight minimal implementation of a batched and stack matrix based Canvas with WebGL backend </li>
+				<li> <a href="https://github.com/kittykatattack/ga">Ga</a> - tiny, cute and friendly system for making HTML5 games </li>
+				<li> <a href="https://github.com/xem/platform-engine">platform-engine</a> - 2D platform engine that handles collisions, slopes, rotations, etc. </li>
+				<li> <a href="https://github.com/voronianski-on-games/js13kGames-boilerplate">js13kGames-boilerplate</a> - includes game loop, utility functions and webpack config to package game with just one command </li>
+				<li> <a href="https://github.com/sz-piotr/js13k-webpack-starter">js13k-webpack-starter</a> - build with a single command, dev server, es2015 support </li>
+				<li> <a href="https://github.com/aerze/js13k-base">js13k-base</a> - simple commands, a server, and a sample game + framework </li>
+				<li> <a href="https://github.com/mtmckenna/js13k-webpack-typescript-starter-party">js13k-webpack-typescript-starter-party</a> - starter Webpack project to transpile TypeScript, build, and zip your game </li>
+				<li> <a href="https://github.com/kata-codes/js13k-typescript-starter">js13k-typescript-starter</a> - adapted from <a href="https://github.com/mtmckenna/js13k-webpack-typescript-starter-party">js13k-webpack-typescript-starter-party</a>, npm version </li>
+				<li> <a href="https://github.com/mtmckenna/js13kgames-parcel-starter">js13kgames-parcel-starter</a> - starter repo to build, zip, and check the file size of your game with a single command </li>
+				<li> <a href="https://github.com/xem/responsiveTouchGameFramework">responsiveTouchGameFramework</a> - responsive canvas game framework with unified mouse / tactile inputs </li>
+				<li> <a href="https://twitter.com/MaximeEuziere/status/883044404453294080">Tweetwork</a> - a 140b canvas game framework </li>
+				<li> <a href="https://straker.github.io/kontra/">Kontra</a> - a lightweight JavaScript gaming micro-library, optimized for js13kGames </li>
+				<li> <a href="https://github.com/Rybar/js13k2017kit">JS13K 2017 Kit</a> - a pico-8 like graphics engine and game boilerplate </li>
+				<li> <a href="https://github.com/jonathan-vallet/js13k-starter">JS13K starter</a> - gulp starter watching changes, and tasks to compile, minify, inline, and zip you game for better optimization </li>
+				<li> <a href="https://github.com/kutuluk/js13k-ecs">js13k-ecs</a> - a 1kb entity component system, designed for js13k </li>
+				<li> <a href="https://github.com/kutuluk/js13k-2d">js13k-2d</a> - a &lt;2kb 2D WebGL renderer, designed for js13k </li>
+				<li> <a href="https://github.com/lpagg/floppy">floppy</a> - a micro game engine for beginners </li>
+				<li> <a href="https://github.com/xem/CSS3Dframework">CSS3Dframework</a> - a hackable ~1.7kb framework to display and animate CSS3D shapes </li>
+				<li> <a href="https://twitter.com/MaximeEuziere/status/1157563570823081984">MiniDragAndDrop</a> - a DOM-based, easy-to-use drag&drop library for desktop and mobile browsers (639 bytes) </li>
+				<li> <a href="https://github.com/xem/mini2Dphysics/">Mini2Dphysics</a> - a 1.5kb 2D physics engine. Just set the gravity, create Circles and Rectangles, and watch them fall and collide. (see index.html) </li>
+				<li> <a href="https://jabo-bernardo.github.io/jabo-micro-game-engine/">Jabo Micro Game Engine</a> - lightweight and beginner friendly micro game engine </li>
+				<li> <a href="https://github.com/swashvirus/craters.js">Craters.js mini game framework</a> - simple to use hackable framework, compact at ~2kb zipped leaving enough room for game logic </li>
+				<li> <a href="https://twitter.com/MaximeEuziere/status/1257783623316656130">280 bytes responsive, hackable, mobile friendly game framework</a> with native arrow keys / WASD / ZQSD key inputs detection </li>
 			</ul>
-		</li>
-		<li><a href="http://fireside.gamejolt.com/post/7-great-js13k-2015-games-icyrzrkp">7 Great JS13K 2015 Games</a> by Paul Hack at Gamejolt Fireside</li>
-		<li><a href="http://fireside.gamejolt.com/post/jam-favorites-js13kgames-jam-fax27wgm">Jam Favorites: JS13KGames Jam</a> by Jupiter Hadley at Gamejolt Fireside</li>
-		<li><a href="https://hacks.mozilla.org/2016/08/js13kgames-code-golf-for-game-devs/">js13kGames: Code golf for game devs</a> - 2015 winners share their JavaScript tips and tricks at Mozilla Hacks</li>
-		<li><a href="http://blog.codility.com/2016/08/game-development-javascript-and-codility.html">Game Development, JavaScript and Codility</a> - interview with FatFisz recruited by Codility after js13k 2015</li>
-		<li class="posts" id="posts2016"><strong>2016 post-mortems:</strong>
+			<h3 id="sfx">Sound and music</h3>
 			<ul>
-				<li><a href="https://xem.github.io/articles/js13k16.html">Super Chrono Portal Maker</a> by Xem</li>
-				<li><a href="https://walsh9.net/games/yoctopets-post-mortem">yoctoPets</a> by Walsh9</li>
-				<li><a href="http://theperplactory.net/postmortem-js13k-2016/">Shuttle Power Dash</a> by Mary Bush</li>
-				<li><a href="https://github.com/PixelJerry/JS13K_Nexus_overload/wiki/Making-of-Nexus-overload">Nexus Overload</a> by Pixel Jerry</li>
-				<li><a href="https://github.com/vonloxx/js13k-2016/">PULSE</a> by Marco Fernandes</li>
-				<li><a href="https://medium.com/@herebefrogs/blade-gunner-js13kgames-2016-post-mortem-6786d2237733">Blade Gunner</a> by Jerome Lecomte</li>
-				<li><a href="https://jamesswright.co.uk/blog/1474997-glitch-hunt-js13kgames-2016">Glitch Hunt</a> by James Wright</li>
-				<li><a href="https://github.com/plissken2013es/glitch-torpedo-js13k2016/blob/master/README.md">Glitch Torpedo</a> by Plissken2013es</li>
-				<li><a href="https://brosteins.com/2016/09/17/js13kgames-2016/">Nomis 2</a> by Nick Branstein</li>
-				<li><a href="http://zofiakorcz.pl/buggy-snake">Buggy SnAkE</a> by Zosia Korcz</li>
-				<li><a href="http://crocidb.com/articles/postmortem-phosphorus-dating.html">Phosphorus Dating</a> by Bruno Croci</li>
+				<li> <a href="http://sb.bitsnbites.eu/">SoundBox</a> - an HTML5 synth music tracker </li>
+				<li> <a href="https://github.com/mneubrand/jsfxr">jsfxr</a> - <a href="http://www.superflashbros.net/as3sfxr/">as3sfxr</a> synth port to JavaScript </li>
+				<li> <a href="http://codepen.io/jackrugile/blog/arcade-audio-for-js13k-games">Arcade audio for js13kGames</a> - blog post about generating your own sound effects </li>
+				<li> <a href="https://github.com/nicolas-van/sonant-x">Sonant-X</a> - small JavaScript synthesizer library </li>
+				<li> <a href="http://www.cappel-nord.de/webaudio/">Web Audio API prototypes</a> - demos using the Web Audio API to synthesize audio in the browser </li>
+				<li> <a href="https://github.com/kevincennis/TinyMusic">TinyMusic</a> - simple, lightweight music synth/sequencer in JavaScript using the Web Audio API </li>
+				<li> <a href="https://github.com/xem/miniMusic">miniMusic</a> - draw a melody with your mouse, choose the tempo, volume and base note, then export it as a super short JS code </li>
+				<li> <a href="https://www.google.com/logos/2017/fischinger/fischinger17.html">Google Music Creator</a> - a simple music creator by Google </li>
+				<li> <a href="https://zzfx.3d2k.com">ZzFX</a> - Zuper Zmall Zeeded Zound Zynth </li>
 			</ul>
-		</li>
-		<li><a href="https://github.com/blog/2409-build-a-game-in-13kb-or-less-with-js13kgames">Build a game in 13kB or less with js13kGames</a> - a recap of some entries from previous years and GitHub's invitation to 2017</li>
-		<li><a href="https://hacks.mozilla.org/2017/08/a-frame-comes-to-js13kgames/">A-Frame comes to js13kGames: build a game in WebVR</a> - Mozilla Hacks introducing new A-Frame category in 2017</li>
-		<li><a href="https://blog.jscrambler.com/interview-game-development-using-javascript/">Interview with Andrzej Mazur - Game Development Using JavaScript</a> - Jscrambler blog post</li>
-		<li><a href="https://udxs.me/js13kgames/">What is the js13kGames competition?</a> - blog post by Davit Markarian</li>
-		<li><a href="https://www.freecodecamp.org/news/lesser-known-developer-contests-you-can-join-in-2018-bf70f175106a/">Lesser-known developer contests you can join in 2018</a> by Mike Sedzielewski at FreeCodeCamp</li>
-		<li class="posts" id="posts2017"><strong>2017 post-mortems:</strong>
+			<h3 id="gfx">Artwork and fonts</h3>
 			<ul>
-				<li><a href="http://64mega.github.io/js13k-postmortem-2017.html">Lost In Labyrinth</a> by Daniel Lawrence</li>
-				<li><a href="https://medium.com/@scriptnull/scribble-82c04fb6f7d3">Scribble</a> by Vishnu Bharathi</li>
-				<li><a href="http://dhmstark.co.uk/articles/the-fish-are-too-smart/">Adrift</a> by David Stark</li>
-				<li><a href="http://twelvegamesayear.blogspot.co.za/2017/09/js13k-2017-lost-packets-retrospective.html">The Lost Packets</a> by Andrew Higson-Smith</li>
-				<li><a href="https://xem.github.io/articles/js13k17.html">LOSSST</a> by Maxime EUZIERE (warning: big ass story: 10500 words + 80MB of images)</li>
-				<li><a href="http://code.ryanmalm.com/JS13k_2017_postmortem">Greeble</a> by Ryan Malm</li>
-				<li><a href="https://blog.slashie.net/2017/09/30/postmortem-lost-in-asterion-js13k-2017/">Lost in Asterion</a> by Santiago Zapata &frasl; Slashie</li>
-				<li><a href="http://zofiakorcz.pl/lost-in-cyberspace-vr">Lost in Cyberspace</a> by Zosia Korcz</li>
-				<li><a href="https://www.mattiafortunati.com/a-day-in-the-life-and-js13kgames-2017/">A Day in the Life</a> by Mattia Fortunati</li>
-				<li><a href="https://medium.com/@zendrael/ipad-only-gamedev-11-enough-to-compete-6aeb1f033668">Lost in Jungle</a> by Zendrael</li>
-				<li><a href="https://github.com/gre/js13k-2017#mea-culpa">AMAZ3D</a> by Gaëtan Renaudeau</li>
-				<li><a href="https://chrpaul.de/2017/09/js13kGames-A-Frame-jam.html">Fly South</a> by Christian Paul</li>
-				<li><a href="https://curiositymotive.com/developing-under-extreme-constraints/">The Forest</a> by Alex Porter</li>
-				<li><a href="https://nifey.github.io/2017/10/20/Lost-in-the-woods-My-entry-for-JS13Kgames.html">Lost in the woods</a> by Abdun Nihaal</li>
-				<li><a href="https://medium.com/@herebefrogs/a-tourist-in-paris-js13kgames-2017-post-mortem-29a75197be6f">A Tourist In Paris</a> by Jerome Lecomte</li>
-				<li><a href="https://platane.github.io/js13k-2017/postmortem/">Vernissage</a> by Platane</li>
+				<li> <a href="http://opengameart.org">OpenGameArt</a> - free graphics assets </li>
+				<li> <a href="http://codepen.io/agares/pen/CtxuE/">Sprite generator</a> - 1 color sprite interpreter </li>
+				<li> <a href="http://www.iquilezles.org/www/articles/voronoise/voronoise.htm">Voronoise</a> - procedural pattern generation </li>
+				<li> <a href="https://github.com/download13/blockies">Blockies</a> - identicon generation </li>
+				<li> <a href="http://pixelmap.amcharts.com/">Pixel map generator</a> - generate pixel maps </li>
+				<li> <a href="http://www.pixenapp.com/">Pixen</a> - pixel art editor for Mac OS X </li>
+				<li> <a href="http://compresspng.com/">CompressPNG</a> - compress PNGs online </li>
+				<li> <a href="http://tinypng.com/">TinyPNG</a> - advanced lossy compression for PNG images that preserves full alpha transparency </li>
+				<li> <a href="https://github.com/PaulBGD/PixelFont">Pixel Font</a> - tiny pixel font </li>
+				<li> <a href="https://github.com/xem/js13k-graphics-editor">js13k-graphics-editor</a> - Draw with your mouse and export the result as a tiny JS snippet </li>
+				<li> <a href="http://www.piskelapp.com/">Piskel</a> - Pixel Art and Animated Sprites </li>
+				<li> <a href="http://www.aseprite.org/">aseprite</a> - animated sprite editor &amp; pixel art tool </li>
+				<li> <a href="http://pyxeledit.com">Pyxel Edit</a> - is a pixel art editor designed to make it fun and easy to make tilesets, levels and animations </li>
+				<li> <a href="https://xem.github.io/miniPixelFont/">mini pixel font</a> - Generate your pixel-art font with a few lines of JS </li>
+				<li> <a href="https://github.com/madmarcel/js13k-mini-svg-editor">js13k mini-svg editor</a> - Create mini-svg graphics for your js13k game using a webbased editor </li>
+				<li> <a href="https://github.com/xem/js13k-path">js13k-path</a> - draw polygons where every point is encoded on 1 ASCII char </li>
+				<li> <a href="https://xem.github.io/miniPixelArt/">MiniPixelArt</a> - a 8-color pixel-art editor and exporter (pure JS, no PNG) </li>
+				<li> <a href="https://github.com/xem/twemoji-webfont">Twemoji-webfont</a> - helps you live-load an Emoji webfont for any browser, after asking the user if he/she's okay </li>
+				<li> <a href="https://codepen.io/xem/pen/OoXpmM?editors=1000">SVGenerator</a> - a dynamic SVG generator with custom colors </li>
+				<li> <a href="https://xem.github.io/CSS3D/">CSS3D</a> - The shortest way to write CSS3D cubes, pyramids and sprites ( <a href="https://github.com/xem/CSS3D/blob/gh-pages/index.html">source code</a>) </li>
+				<li> <a href="http://canvas-txt.geongeorge.com/">Canvas-Txt</a> - The better way to print multiline text on HTML5 canvas with auto line breaks and alignments ( <a href="https://github.com/geongeorge/Canvas-Txt">source code</a>) </li>
+				<li> <a href="https://spritestack.io/">SpriteStack</a> - SpriteStack is a voxel editor suited for 2D artists featuring hand crafted retro renderer with animation support. It exports spritesheets, slices and vox models. </li>
+				<li> <a href="https://github.com/darkwebdev/tinyfont.js">tinyfont.js</a> - Tiniest possible pixel font for your JS games (<700b zipped)! </li>
+				<li> <a href="https://xem.github.io/emoji/">emoji</a> - a webfont that can be loaded from your entry to fix/complete the emoji that can be seen by all your future players </li>
 			</ul>
-		</li>
-		<li><a href="https://hacks.mozilla.org/2018/01/lessons-learned-from-the-a-frame-category-in-the-js13kgames-competition/">Lessons learned from the A-Frame category in the js13kGames competition</a> - tips and tricks from the WebVR category</li>
-		<li><a href="http://dev.end3r.com/2018/02/organizing-a-successful-competition-that-doesnt-scale/">Organizing a successful competition that doesn’t scale</a> - a look back at a few issues that occured  during js13kGames 2017</li>
-		<li><a href="https://blog.github.com/2018-08-09-create-a-13kb-javascript-game-in-30-days-with-js13kgames/">Create a 13 kB JavaScript game in 30 days with js13kGames</a> - GitHub's tips and tricks article by Lee Reilly</li>
-		<li class="posts" id="posts2018"><strong>2018 post-mortems:</strong>
+			<h3 id="mini">Minification</h3>
 			<ul>
-				<li><a href="https://fq.nz/blog/2018/08/30/my-js13k-games-entry-13kars.html">13Kars</a> by Kesara</li>
-				<li><a href="https://github.com/nickshillingford/js13kGames-Disconnected/blob/master/README.md">Disconnected</a> by Nick Shillingford</li>
-				<li><a href="https://github.com/BenjaminWFox/offline-oect-js13k/blob/master/readme.md">Offline: O.E.C.T</a> by Ben Fox</li>
-				<li><a href="https://steemit.com/steemmonsters/@mys/development-of-goblin-tower-13k-for-steem-monsters-game-jam">Goblin Tower 13k</a> by Mys</li>
-				<li><a href="https://github.com/codyebberson/js13k-battlegrounds#postmortem">JS13K Battlegrounds</a> by Cody Ebberson</li>
-				<li><a href="https://medium.com/@etchells.kevin/off-the-lines-a-js13k-game-cfa4ad6f0ee6">Off The Lines</a> by Kev Etchells</li>
-				<li><a href="https://medium.com/@etchells.kevin/you-are-offline-a-js13k-game-2a497347ecad">You Are Offline</a> by Kev Etchells</li>
-				<li><a href="https://sebadorn.de/2018/09/15/js13kgames-tricks-applied-in-risky-nav">Risky Nav</a> by Sebastian Dorn</li>
-				<li><a href="https://github.com/starzonmyarmz/js13k-2018#post-mortem">ONOFF</a> by Daniel Marino</li>
-				<li><a href="https://medium.com/@vik.ugrin/hoverla-the-little-story-js13kgames-ff73042951c1">[Hoverla]</a> by Viktor Uhryn</li>
-				<li><a href="https://github.com/nesrak1/systems/wiki/Post-Mortem">SYSTEMS</a> by nesrak1</li>
-				<li><a href="https://github.com/asisaa/13kGame/blob/master/postmortem.md">Bo the Dog</a> by Asisa</li>
-				<li><a href="https://mattdesl.svbtle.com/bellwoods">Bellwoods</a> by Matt DesLauriers</li>
-				<li><a href="https://phoboslab.org/log/2018/09/underrun-making-of">Underrun</a> by Dominic Szablewski</li>
-				<li><a href="https://jaenis.ch/blog/js13kgames-postmortem-an-offline-life/">An Offline Life</a> by André Jaenisch</li>
-				<li><a href="https://www.barbarianmeetscoding.com/blog/2018/09/19/how-to-write-a-game-under-13k-while-taking-care-of-a-baby">Earth That Was</a> by Jaime Gonzalez Garcia</li>
-				<li><a href="https://js13k.lucasbersier.com/the-post-partum-article">When my vpn goes offline(...)</a> by Lucas Bersier</li>
-				<li><a href="https://github.com/picosonic/js13k-2018/blob/master/devdiary/diary.md">Planet Figadore has gone OFFLINE</a> by picosonic (Jasper Renow-Clarke)</li>
-				<li><a href="https://github.com/bojanpejkovic/wired/blob/master/pm.md">Wired</a> by Bojan Pejkovic</li>
-				<li><a href="http://hambley.me.uk/Blog/diaryofagame">Watashi no Shashin</a> by Brian Hambley</li>
-				<li><a href="https://shreyasminocha.me/blog/js13k-2018-postmortem/">WiFiHunt</a> by Shreyas Minocha</li>
-				<li><a href="https://timmykokke.com/post/2018-09-18-js13kgames-2018-postmortem/">Lasergrid</a> by Timmy Kokke</li>
-				<li><a href="http://jack-oatley.com/index.php?post=blog/2018_09_17_Exo.html">Exo</a> by Jack Oatley</li>
-				<li><a href="https://samirhodzic.github.io/2018/09/26/quest-of-tod-flow/">Quest of Tod</a> by Samir Hodzic</li>
-				<li><a href="https://github.com/mccordgh/the_line_js13kgames_2018/blob/master/README.md">The Core</a> by Matthew McCord</li>
-				<li><a href="https://demo.land/blog/2018/10/02/whirled-js-game-jam-code/">Whirled on the JS Game Jam Code</a> by Andras Serfozo</li>
-				<li><a href="https://engineering.wingify.com/posts/js13k-game-development/#twisty-polyhedra">Twisty Polyhedra</a> by Aditya Mishra</li>
-				<li><a href="https://engineering.wingify.com/posts/js13k-game-development/#keep-alive">Keep-Alive</a> by Surbhi Mahajan</li>
-				<li><a href="https://engineering.wingify.com/posts/js13k-game-development/#anti_virus">Anti_Virus</a> by Punit Gupta</li>
-				<li><a href="https://engineering.wingify.com/posts/js13k-game-development/#sum-it-up">Sum It Up</a> by Hemkaran Raghav</li>
-				<li><a href="https://engineering.wingify.com/posts/js13k-game-development/#up--down">Up &amp; Down</a> by Dinkar Pundir</li>
-				<li><a href="https://engineering.wingify.com/posts/js13k-game-development/#robo-galactic-shooter">Robo Galactic Shooter</a> by Ashish Bardhan</li>
-				<li><a href="https://xem.github.io/articles/js13k18.html">Geoquiz2 / Envelope / Man on Wire</a> by xem & friends</li>
-				<li><a href="https://archiewald.github.io/blog/1ppm/2018/10/09/js13k-my-first-game.html"> KickIt!</a> by archiewald</li>
-				<li><a href="https://blog.slashie.net/2018/10/18/postmortem-archerfire-duet-of-aces-js13k-2018/">ArcherFire: Duet of Aces</a> by Santiago Zapata</li>
-				<li><a href="https://github.com/nrkn/js13k-2018/blob/master/README.md">Ranger Down</a> by Nik Coughlin</li>
-				<li><a href="https://medium.com/@herebefrogs/submersible-warship-2063-a-js13kgames-2018-postmortem-380b0008dc50">SUBmersible WARship 2063</a> by Jerome Lecomte</li>
-				<li><a href="https://github.com/chiaogu/planetfall">Planetfall</a> by Ian Chiao</li>
+				<li> <a href="https://babeljs.io/repl">babeljs</a> - JS (ES2015/2016/2017) minifier based on Babili, choose your flavor in the "presets" dropdown </li>
+				<li> <a href="http://dean.edwards.name/packer/">Packer</a> - JavaScript compressor </li>
+				<li> <a href="http://javascript-minifier.com/">JavaScript Minifier</a> - minify your JavaScript </li>
+				<li> <a href="https://github.com/Siorki/RegPack">RegPack</a> - self-contained packer for size-constrained JS code </li>
+				<li> <a href="http://closure-compiler.appspot.com/home">Closure Compiler</a> - compile your code </li>
+				<li> <a href="https://github.com/mishoo/UglifyJS">UglifyJS</a> - JavaScript parser / mangler / compressor / beautifier library for NodeJS </li>
+				<li> <a href="http://www.slideshare.net/DavidGoemans/extreme-javascript-minification">Extreme Javascript minification</a> - compression experiments </li>
+				<li> <a href="http://www.advancemame.it/download">ADVZIP</a> - zip file optimizer / recompressor (can reduce a 13kb zip to 9~11kb) </li>
+				<li> <a href="https://github.com/xem/miniMinifier/">miniMinifier</a> - tiny (but super efficient) HTML and CSS minifiers </li>
+				<li> <a href="http://www.minifier.org/">Minify</a> - a JavaScript and CSS minifier </li>
+				<li> <a href="https://jscompress.com/">JSCompress</a> - a compression tool for javascript </li>
+				<li> <a href="https://github.com/codegolf/zpng">ZPNG Minifier</a> - in-browser jsExe </li>
+				<li> <a href="https://xem.github.io/int2binary2html/">int2binary2html</a> - helps you to encode a long list of integers (0-255) in binary and embed it in your index.html </li>
+				<li> <a href="https://xem.github.io/terser-online/">Terser-online</a> - a live version of the Terser ES6+ minifier, with extra compression options because every byte counts </li>
 			</ul>
-		</li>
-		<li><a href="https://blog.github.com/2018-10-05-js13kgames-highlights-2018/">13 Games in ≤ 13kB of JavaScript</a> - GitHub's highlights by Lee Reilly</li>
-		<li><a href="https://www.kotaku.com.au/2018/10/all-these-amazing-browser-games-take-up-13-kilobytes-or-less/">These amazing browser games are 13 kilobytes or less in size</a> by Logan Booker at Kotaku.com.au</li>
-		<li><a href="https://thenewstack.io/tiny-javascript-games-from-the-js13kgames-competition/">Tiny JavaScript games from the JS13kGames competition</a> by David Cassel at The New Stack</li>
-		<li><a href="https://github.blog/2019-08-07-eighth-annual-js13kgames-challenge/">Eighth annual js13kGames challenge</a> by Lee Reilly on GitHub's blog</li>
-		<li><a href="https://ebaytech.berlin/js13kgames-a-review-c10cbe9a39e3/">js13kGames — a review</a> by eBay Tech</li>
-		<li><a href="https://www.vice.com/en_us/article/43k453/this-real-time-strategy-game-is-just-13-kilobytes">This Real Time Strategy Game Is Just 13 Kilobytes</a> by Karl Bode at Vice Games</li>
-		<li><a href="https://github.blog/2019-10-08-js13k-2019-highlights/">Highlights from the js13kGames 2019 competition</a> - top 10 winners showcased by Lee Reilly on GitHub's blog</li>
-		<li class="posts" id="posts2019"><strong>2019 post-mortems:</strong>
+			<h3 id="aframe">WebXR resources</h3>
 			<ul>
-				<li><a href="https://unboring.net/cases/progressive-webxr-game/">Making a Progressive WebXR game with 13Kb + three.js</a> by Arturo Paracuellos</li>
-				<li><a href="https://github.com/vonloxx/js13k-2019/blob/master/README.md">Back To The Stars</a> by Marco Fernandes</li>
-				<li><a href="https://auroriax.com/js13kgames-back-to-the-basics/">BackFlipped: Back to the Basics</a> by Tom Hermans (@Auroriax)</li>
-				<li><a href="https://medium.com/@niklas.b3rg/game-dev-postmortem-backstabber-hero-part-1-80c7def92c74">Backstabber Hero (Part 1 - Sources of inspiration)</a> by Niklas Berg (@nkholski)</li>
-				<li><a href="http://xem.github.io/articles/js13k19.html">Back on Track (mania)</a> by xem</li>
-				<li><a href="https://dev.to/mrlopis/how-to-design-a-javascript-game-in-13kb-or-less-59kn">How to design a javascript game? (in 13KB or less)</a> by Joao Lopes (@mrlopis)</li>
-				<li><a href="https://github.com/DennisBengs/retrohaunt/tree/master/postmortem">Retrohaunt</a> by Donitz</li>
-				<li><a href="https://medium.com/@alexc73/i-made-a-video-game-on-my-journey-to-work-8e1bf2dfd208">Back from Kooky Island</a> by Alexander Curtis</li>
-				<li><a href="https://dev.to/mrlopis/creating-a-13kb-js-game-using-svg-5fjk">Creating a 13KB JS Game using SVG</a> by Joao Lopes (@mrlopis)</li>
-				<li><a href="https://medium.com/@etchells.kevin/js13k-games-2019-entry-get-back-from-robot-city-22a48afe5fe">Get Back From Robot City</a> by Kev Etchells</li>
-				<li><a href="https://github.com/picosonic/js13k-2019/blob/master/devdiary/diary.md">BACKSPACE - Return to planet Figadore</a> by picosonic (Jasper Renow-Clarke) (@femtosonic)</li>
-				<li><a href="https://github.com/amolinasalazar/LightsBackOn/blob/master/README.md">Lights Back On</a> by Alejandro Molina (@amolinasalazar)</li>
-				<li><a href="https://carelesslabs.wordpress.com/2019/09/19/js13k-game-jam-post-mortom-gamedev-js13k">Quick Wins</a> by Ryan Tyler (<a href="https://twitter.com/CarelessLabs">@Carelesslabs</a>)</li>
-				<li><a href="https://vertfromage.github.io./update/2019/09/19/entering-JS13KGames-2019-beginner.html">Backside Ball - Entering JS13KGames 2019 as a Beginner</a> by Vertfromage</li>
-				<li><a href="https://blog.slashie.net/2019/09/22/backpack-monsters-js13k-2019/">Backpack Monsters</a> by @slashie_</li>
-				<li><a href="https://phoboslab.org/log/2019/09/voidcall-making-of">The Making of VOIDCAL</a> by Dominic Szablewski</li>
-				<li><a href="https://github.com/jaammees/racer/blob/master/README.md">Racer</a> by James</li>
-				<li><a href="https://dev.to/johnkilmister/random-learnings-from-entering-js13k-games-2019-4pcn">Random Learnings from Entering JS13K Games 2019</a> by <a href="https://twitter.com/JohnKilmister">@JohnKilmister</a></li>
-				<li><a href="https://64mega.github.io/js13k-2019-recap.html">JS13k 2019 Developer Commentary</a> by Daniel Lawrence (<a href="https://twitter.com/64Mega">@64Mega</a>)</li>
-				<li><a href="https://dev.to/salvan13/backshot-tactics-a-multiplayer-game-for-js13kgames-47ie">Backshot Tactics - A Multiplayer Game for js13kGames</a> by Antonio Salvati (<a href="https://twitter.com/salvan13">@salvan13</a>)</li>
-				<li><a href="https://medium.com/@mateusz.tomczyk/a-story-of-making-a-13-kb-game-in-30-days-the-wandering-wraith-post-mortem-9847c8992f49">A story of making a 13 kB game in 30 days. “The Wandering Wraith” post mortem.</a> by Mateusz Tomczyk</li>
-				<li><a href="https://serpent7776.itch.io/back-to-life/devlog/100709/back-to-life-postmortem">Back to life</a> by <a href="https://twitter.com/serpent7776">Serpent7776</a></li>
-				<li><a href="https://medium.com/@herebefrogs/dont-look-back-a-js13kgames-2019-postmortem-a0028d8acef2">Do Not Look Back!</a> by <a href="https://twitter.com/herebefrogs">Jerome Lecomte</a></li>
-			        <li><a href="https://www.deadpix3l.com/bubbas-back-room-postmortem">Bubba's Back Room</a> by <a href="https://twitter.com/ericdrowell">Eric Rowell</a></li>
-				<li><a href="http://frankforce.com/?p=6936">Bounce Back Postmortem: A Boomerang Adventure</a> by <a href="https://twitter.com/KilledByAPixel">Frank Force</a></li>
-				<li><a href="https://piesku.com/backcountry">Backcountry</a> by Michał Budzyński and Staś Małolepszy</li>
+				<li> <a href="https://aframe.io/docs/0.6.0/introduction/#getting-started">A-Frame Documentation</a> - introduciton to A-Frame </li>
+				<li> <a href="https://aframevr-slack.herokuapp.com/">A-Frame Slack invitation</a> - ask questions here </li>
+				<li> <a href="https://aframe.io/aframe-registry/">A-Frame Registry</a> - useful components </li>
+				<li> <a href="https://github.com/aframevr/awesome-aframe">Awesome A-Frame</a> - many more A-Frame resources &amp; examples </li>
+				<li> <a href="https://github.com/xem/gyro">Gyro.js</a> - harmonizes the gyroscope/accelerometer output across all mobile devices </li>
+				<li> <a href="https://github.com/mguinea/js13k-aframe-boilerplate">js13k A-Frame Webpack boilerplate</a> - build with a single command, dev server, es2015 support, basic example </li>
 			</ul>
-		</li>
-	</ul>
-
-	<a class="fork page" href="https://github.com/js13kgames/resources" title="Fork me on GitHub"></a>
-	<p class="note">
-		The first version of this list was originally <a href="https://gist.github.com/blueboxes/9818da26141a854cba52">created</a>
-		by <a href="https://github.com/blueboxes">John Kilmister</a>.
-	</p>
-</main>
-
-<footer>
-	<div>
-		&copy; js13kGames 2012-2019
-		<p>Created and maintained by <a target="_blank" href="https://end3r.com">Andrzej Mazur</a> from <a target="_blank" href="https://enclavegames.com">Enclave Games</a>.</p>
-	</div>
-</footer>
-
-</body>
+			<h3 id="other">Other tools</h3>
+			<ul>
+				<li> <a href="http://videogamena.me/">Video Game Name Generator</a> - generate a name for your game </li>
+				<li> <a href="https://github.com/mrdoob/stats.js/">stats.js</a> - JavaScript performance monitor </li>
+				<li> <a href="http://khan.github.io/live-editor/demos/simple/">Live Editor</a> - edit JavaScript code </li>
+				<li> <a href="https://github.com/allouis/minivents">Minivents</a> - small event system for JavaScript </li>
+				<li> <a href="https://gist.github.com/xem/99930986c5333125a13b0ea50600391f">Maths and trigonometry cheat sheet for 2D games</a> </li>
+				<li> <a href="https://github.com/js13kGames/js13kserver">js13kserver</a> - sandboxed JavaScript game server </li>
+				<li> <a href="https://github.com/xem/js13k-level-editor">js13k-level-editor</a> - 1kb 2D map editor that you can use for your game (or include in your game!) </li>
+				<li> <a href="https://github.com/xem/3D-level-editor">3D-level-editor</a> - CSS3D map editor with customizable 3D shapes and 2D sprites </li>
+				<li> <a href="https://github.com/xenohunter/timestore">timestore</a> - library to manage multiple timers inside separate contexts </li>
+				<li> <a href="https://github.com/stasm/innerself">innerself</a> - a React/Redux-like view and state management for your game's UI, in less than 400 bytes </li>
+			</ul>
+			<h3 id="tuts">Tutorials</h3>
+			<ul>
+				<li> <a href="http://gamedevelopment.tutsplus.com/articles/how-to-minify-your-html5-game-for-the-js13kgames-competition--cms-21883">How to minify your HTML5 game for the js13kGames competition</a> </li>
+				<li> <a href="http://www.gamedevacademy.org/js13kgames-tutorial/">js13kGames tutorial - How to make a text game with HTML5</a> </li>
+				<li> <a href="https://hacks.mozilla.org/2013/09/getting-started-with-html5-game-development/">Getting started with HTML5 game development</a> </li>
+				<li> <a href="http://codeincomplete.com/posts/2013/5/27/tiny_platformer/">Tiny platformer</a> </li>
+				<li> <a href="http://www.playfuljs.com/a-first-person-engine-in-265-lines/">A first-person engine in 265 lines</a> </li>
+				<li> <a href="http://ojdon.github.io/blog/HTML5-Game-Development-Gulp-Workflow">HTML5 game development Gulp workflow</a> </li>
+				<li> <a href="https://gist.github.com/xem/99930986c5333125a13b0ea50600391f">Trigonometry cheat sheet</a> </li>
+				<li> <a href="https://gamedevacademy.org/js13kgames-tutorial-video-series/">js13kGames tutorial video series by Zenva Academy</a> - create a Frogger game in 13kb or less </li>
+				<li> <a href="https:https://xem.github.io/articles/jsgamesinputs.html">How to support arrow keys, WASD and ZQSD keyboard inputs in just 160b of JS</a> </li>
+				<li> <a href="https://xem.github.io/articles/css3dgames.html">How to make games with CSS3D</a> </li>
+				<li> <a href="https://aframe.io/aframe-school/">A-Frame School</a> </li>
+				<li> <a href="https://medium.com/web-maker/making-asteroids-with-kontra-js-and-web-maker-95559d39b45f">Making Asteroids with Kontra.js and Web Maker</a> - handy tutorial from Steven Lambert, the author of Kontra.js </li>
+				<li> <a href="https://craiky.github.io/tutorial/">Procedurally Generated Dungeon Tutorial</a> </li>
+				<li> <a href="http://7tonshark.com/2018-09-16-web-audio-part-1/">Creating simple music using the Web Audio API</a> </li>
+				<li> <a href="https://xem.github.io/articles/webgl-guide.html">WebGL guide</a> </li>
+			</ul>
+			<h3 id="vids">Videos and audio</h3>
+			<ul>
+				<li> <a href="https://www.youtube.com/playlist?list=PLYKU1lvSF85cletut9NULJwgEtN01TYWm">Jupi Plays Indie Games 2014</a> - YouTube playlist with Jupiter Hadley playing all the games from the 2014 edition </li>
+				<li> <a href="https://www.youtube.com/playlist?list=PL94Kxubp5fYe3XwC3rIeybFUhIkeuhJym">Let's play vids for js13k 2015</a> - YouTube playlist for 2015 entries by Keith Karnage </li>
+				<li> <a href="https://www.youtube.com/playlist?list=PLYKU1lvSF85czCO1G2UgwvxRpzGw8P2Bn">Jupi Plays Indie Games 2015</a> - YouTube playlist for 2015 entries by Jupiter Hadley </li>
+				<li> <a href="https://www.youtube.com/playlist?list=PLYKU1lvSF85e_jRg9g12GhpATCW1ETrb1">Jupi Plays Indie Games 2016</a> - YouTube playlist for 2016 entries by Jupiter Hadley </li>
+				<li> <a href="https://www.youtube.com/watch?v=8gSTuXrFyIc">JS13K 2017 games compilation</a> - YouTube video by Agar3s </li>
+				<li> <a href="https://www.youtube.com/playlist?list=PLYKU1lvSF85c4UPV3J1onIf-Qv13GJ7H8">Jupi Plays Indie Games 2017</a> - YouTube playlist for 2017 entries by Jupiter Hadley </li>
+				<li> <a href="https://soundcloud.com/the-game-developers-radio/game-design-daily-068-game-dev-article-round-up-part-02">The Game Developers Radio: Game Design Daily 068</a> - game dev article round up part 02 on SoundCloud </li>
+				<li> <a href="https://www.youtube.com/watch?v=RdOram609vU">How to squeeze a HTML5 game in 13 kB?</a> - Andrzej Mazur's introductory speech. Subtitles by B0dz1o </li>
+				<li> <a href="https://edgeguard.podbean.com/e/111-js13k/">Edge Guard podcast #111 about js13kGames 2019</a> </li>
+			</ul>
+			<h3 id="posts">Blog posts and post mortems</h3>
+			<ul>
+				<li> <a href="https://gabor.heja.hu/blog/2018/04/25/untitled13/">untitled13</a> by Gabor Heja </li>
+				<li class="posts" id="posts2015"> <strong>2015 post-mortems:</strong>
+					<ul>
+						<li> <a href="https://brosteins.com/2015/09/13/js13kgames-2015/">Nomis</a> by Nick Branstein </li>
+						<li> <a href="https://github.com/EduardoLopes/js13kgames-2015/blob/master/README.md">Tiny Stealth</a> by Eduardo Lopes </li>
+						<li> <a href="http://jamesswright.co.uk/blog/1442177-time-worm-js13kgames-entry">Time Worm</a> by James Wright </li>
+						<li> <a href="http://blog.kodewerx.org/2015/09/its-lovely-day-for-postmortem.html">It's a Lovely Day for a Drive</a> by Jay Oster </li>
+						<li> <a href="http://bitowl.net/raw-space/">Raw | space</a> by Bitowl </li>
+						<li> <a href="https://xem.github.io/articles/js13k15.html">GeoQuiz</a> by Maxime Euzière </li>
+						<li> <a href="https://github.com/gre/behind-asteroids/blob/master/README.md">Behind Asteroids — The Dark Side</a> by Gaëtan Renaudeau </li>
+						<li> <a href="http://giddyplanet.com/2015/09/galactic-backfire-a-retrospective-of-my-js13k-entry/">Galactic Backfire</a> by Rene Hangstrup Møller </li>
+						<li> <a href="https://ash.ms/blog/2015-09-17/road-blocks">Road Blocks</a> by Ash Kyd </li>
+						<li> <a href="https://github.com/morazor/TCM/wiki">The Cursed Mirror</a> by Marco Emiliozzi </li>
+						<li> <a href="https://github.com/madmaw/LD33/blob/master/README.md">Poust</a> by Chris Glover </li>
+						<li> <a href="https://github.com/MakeshiftMitten/bombsaway/blob/master/README.md">Bombs Away</a> by Makeshift Mitten </li>
+						<li> <a href="http://www.loganfranken.com/blog/1226/my-second-js13k/">ParaTec Systems</a> by Logan Franken </li>
+						<li> <a href="https://gabor.heja.hu/blog/2018/05/16/bokosan-a-reverse-sokoban/">Bokosan</a> by Gabor Heja </li>
+					</ul>
+				</li>
+				<li> <a href="http://fireside.gamejolt.com/post/7-great-js13k-2015-games-icyrzrkp">7 Great JS13K 2015 Games</a> by Paul Hack at Gamejolt Fireside </li>
+				<li> <a href="http://fireside.gamejolt.com/post/jam-favorites-js13kgames-jam-fax27wgm">Jam Favorites: JS13KGames Jam</a> by Jupiter Hadley at Gamejolt Fireside </li>
+				<li> <a href="https://hacks.mozilla.org/2016/08/js13kgames-code-golf-for-game-devs/">js13kGames: Code golf for game devs</a> - 2015 winners share their JavaScript tips and tricks at Mozilla Hacks </li>
+				<li> <a href="http://blog.codility.com/2016/08/game-development-javascript-and-codility.html">Game Development, JavaScript and Codility</a> - interview with FatFisz recruited by Codility after js13k 2015 </li>
+				<li class="posts" id="posts2016"> <strong>2016 post-mortems:</strong>
+					<ul>
+						<li> <a href="https://xem.github.io/articles/js13k16.html">Super Chrono Portal Maker</a> by Xem </li>
+						<li> <a href="https://walsh9.net/games/yoctopets-post-mortem">yoctoPets</a> by Walsh9 </li>
+						<li> <a href="http://theperplactory.net/postmortem-js13k-2016/">Shuttle Power Dash</a> by Mary Bush </li>
+						<li> <a href="https://github.com/PixelJerry/JS13K_Nexus_overload/wiki/Making-of-Nexus-overload">Nexus Overload</a> by Pixel Jerry </li>
+						<li> <a href="https://github.com/vonloxx/js13k-2016/">PULSE</a> by Marco Fernandes </li>
+						<li> <a href="https://medium.com/@herebefrogs/blade-gunner-js13kgames-2016-post-mortem-6786d2237733">Blade Gunner</a> by Jerome Lecomte </li>
+						<li> <a href="https://jamesswright.co.uk/blog/1474997-glitch-hunt-js13kgames-2016">Glitch Hunt</a> by James Wright </li>
+						<li> <a href="https://github.com/plissken2013es/glitch-torpedo-js13k2016/blob/master/README.md">Glitch Torpedo</a> by Plissken2013es </li>
+						<li> <a href="https://brosteins.com/2016/09/17/js13kgames-2016/">Nomis 2</a> by Nick Branstein </li>
+						<li> <a href="http://zofiakorcz.pl/buggy-snake">Buggy SnAkE</a> by Zosia Korcz </li>
+						<li> <a href="http://crocidb.com/articles/postmortem-phosphorus-dating.html">Phosphorus Dating</a> by Bruno Croci </li>
+					</ul>
+				</li>
+				<li> <a href="https://github.com/blog/2409-build-a-game-in-13kb-or-less-with-js13kgames">Build a game in 13kB or less with js13kGames</a> - a recap of some entries from previous years and GitHub's invitation to 2017 </li>
+				<li> <a href="https://hacks.mozilla.org/2017/08/a-frame-comes-to-js13kgames/">A-Frame comes to js13kGames: build a game in WebVR</a> - Mozilla Hacks introducing new A-Frame category in 2017 </li>
+				<li> <a href="https://blog.jscrambler.com/interview-game-development-using-javascript/">Interview with Andrzej Mazur - Game Development Using JavaScript</a> - Jscrambler blog post </li>
+				<li> <a href="https://udxs.me/js13kgames/">What is the js13kGames competition?</a> - blog post by Davit Markarian </li>
+				<li> <a href="https://www.freecodecamp.org/news/lesser-known-developer-contests-you-can-join-in-2018-bf70f175106a/">Lesser-known developer contests you can join in 2018</a> by Mike Sedzielewski at FreeCodeCamp </li>
+				<li class="posts" id="posts2017"> <strong>2017 post-mortems:</strong>
+					<ul>
+						<li> <a href="http://64mega.github.io/js13k-postmortem-2017.html">Lost In Labyrinth</a> by Daniel Lawrence </li>
+						<li> <a href="https://medium.com/@scriptnull/scribble-82c04fb6f7d3">Scribble</a> by Vishnu Bharathi </li>
+						<li> <a href="http://dhmstark.co.uk/articles/the-fish-are-too-smart/">Adrift</a> by David Stark </li>
+						<li> <a href="http://twelvegamesayear.blogspot.co.za/2017/09/js13k-2017-lost-packets-retrospective.html">The Lost Packets</a> by Andrew Higson-Smith </li>
+						<li> <a href="https://xem.github.io/articles/js13k17.html">LOSSST</a> by Maxime EUZIERE (warning: big ass story: 10500 words + 80MB of images) </li>
+						<li> <a href="http://code.ryanmalm.com/JS13k_2017_postmortem">Greeble</a> by Ryan Malm </li>
+						<li> <a href="https://blog.slashie.net/2017/09/30/postmortem-lost-in-asterion-js13k-2017/">Lost in Asterion</a> by Santiago Zapata &frasl; Slashie </li>
+						<li> <a href="http://zofiakorcz.pl/lost-in-cyberspace-vr">Lost in Cyberspace</a> by Zosia Korcz </li>
+						<li> <a href="https://www.mattiafortunati.com/a-day-in-the-life-and-js13kgames-2017/">A Day in the Life</a> by Mattia Fortunati </li>
+						<li> <a href="https://medium.com/@zendrael/ipad-only-gamedev-11-enough-to-compete-6aeb1f033668">Lost in Jungle</a> by Zendrael </li>
+						<li> <a href="https://github.com/gre/js13k-2017#mea-culpa">AMAZ3D</a> by Gaëtan Renaudeau </li>
+						<li> <a href="https://chrpaul.de/2017/09/js13kGames-A-Frame-jam.html">Fly South</a> by Christian Paul </li>
+						<li> <a href="https://curiositymotive.com/developing-under-extreme-constraints/">The Forest</a> by Alex Porter </li>
+						<li> <a href="https://nifey.github.io/2017/10/20/Lost-in-the-woods-My-entry-for-JS13Kgames.html">Lost in the woods</a> by Abdun Nihaal </li>
+						<li> <a href="https://medium.com/@herebefrogs/a-tourist-in-paris-js13kgames-2017-post-mortem-29a75197be6f">A Tourist In Paris</a> by Jerome Lecomte </li>
+						<li> <a href="https://platane.github.io/js13k-2017/postmortem/">Vernissage</a> by Platane </li>
+					</ul>
+				</li>
+				<li> <a href="https://hacks.mozilla.org/2018/01/lessons-learned-from-the-a-frame-category-in-the-js13kgames-competition/">Lessons learned from the A-Frame category in the js13kGames competition</a> - tips and tricks from the WebVR category </li>
+				<li> <a href="http://dev.end3r.com/2018/02/organizing-a-successful-competition-that-doesnt-scale/">Organizing a successful competition that doesn’t scale</a> - a look back at a few issues that occured during js13kGames 2017 </li>
+				<li> <a href="https://blog.github.com/2018-08-09-create-a-13kb-javascript-game-in-30-days-with-js13kgames/">Create a 13 kB JavaScript game in 30 days with js13kGames</a> - GitHub's tips and tricks article by Lee Reilly </li>
+				<li class="posts" id="posts2018"> <strong>2018 post-mortems:</strong>
+					<ul>
+						<li> <a href="https://fq.nz/blog/2018/08/30/my-js13k-games-entry-13kars.html">13Kars</a> by Kesara </li>
+						<li> <a href="https://github.com/nickshillingford/js13kGames-Disconnected/blob/master/README.md">Disconnected</a> by Nick Shillingford </li>
+						<li> <a href="https://github.com/BenjaminWFox/offline-oect-js13k/blob/master/readme.md">Offline: O.E.C.T</a> by Ben Fox </li>
+						<li> <a href="https://steemit.com/steemmonsters/@mys/development-of-goblin-tower-13k-for-steem-monsters-game-jam">Goblin Tower 13k</a> by Mys </li>
+						<li> <a href="https://github.com/codyebberson/js13k-battlegrounds#postmortem">JS13K Battlegrounds</a> by Cody Ebberson </li>
+						<li> <a href="https://medium.com/@etchells.kevin/off-the-lines-a-js13k-game-cfa4ad6f0ee6">Off The Lines</a> by Kev Etchells </li>
+						<li> <a href="https://medium.com/@etchells.kevin/you-are-offline-a-js13k-game-2a497347ecad">You Are Offline</a> by Kev Etchells </li>
+						<li> <a href="https://sebadorn.de/2018/09/15/js13kgames-tricks-applied-in-risky-nav">Risky Nav</a> by Sebastian Dorn </li>
+						<li> <a href="https://github.com/starzonmyarmz/js13k-2018#post-mortem">ONOFF</a> by Daniel Marino </li>
+						<li> <a href="https://medium.com/@vik.ugrin/hoverla-the-little-story-js13kgames-ff73042951c1">[Hoverla]</a> by Viktor Uhryn </li>
+						<li> <a href="https://github.com/nesrak1/systems/wiki/Post-Mortem">SYSTEMS</a> by nesrak1 </li>
+						<li> <a href="https://github.com/asisaa/13kGame/blob/master/postmortem.md">Bo the Dog</a> by Asisa </li>
+						<li> <a href="https://mattdesl.svbtle.com/bellwoods">Bellwoods</a> by Matt DesLauriers </li>
+						<li> <a href="https://phoboslab.org/log/2018/09/underrun-making-of">Underrun</a> by Dominic Szablewski </li>
+						<li> <a href="https://jaenis.ch/blog/js13kgames-postmortem-an-offline-life/">An Offline Life</a> by André Jaenisch </li>
+						<li> <a href="https://www.barbarianmeetscoding.com/blog/2018/09/19/how-to-write-a-game-under-13k-while-taking-care-of-a-baby">Earth That Was</a> by Jaime Gonzalez Garcia </li>
+						<li> <a href="https://js13k.lucasbersier.com/the-post-partum-article">When my vpn goes offline(...)</a> by Lucas Bersier </li>
+						<li> <a href="https://github.com/picosonic/js13k-2018/blob/master/devdiary/diary.md">Planet Figadore has gone OFFLINE</a> by picosonic (Jasper Renow-Clarke) </li>
+						<li> <a href="https://github.com/bojanpejkovic/wired/blob/master/pm.md">Wired</a> by Bojan Pejkovic </li>
+						<li> <a href="http://hambley.me.uk/Blog/diaryofagame">Watashi no Shashin</a> by Brian Hambley </li>
+						<li> <a href="https://shreyasminocha.me/blog/js13k-2018-postmortem/">WiFiHunt</a> by Shreyas Minocha </li>
+						<li> <a href="https://timmykokke.com/post/2018-09-18-js13kgames-2018-postmortem/">Lasergrid</a> by Timmy Kokke </li>
+						<li> <a href="http://jack-oatley.com/index.php?post=blog/2018_09_17_Exo.html">Exo</a> by Jack Oatley </li>
+						<li> <a href="https://samirhodzic.github.io/2018/09/26/quest-of-tod-flow/">Quest of Tod</a> by Samir Hodzic </li>
+						<li> <a href="https://github.com/mccordgh/the_line_js13kgames_2018/blob/master/README.md">The Core</a> by Matthew McCord </li>
+						<li> <a href="https://demo.land/blog/2018/10/02/whirled-js-game-jam-code/">Whirled on the JS Game Jam Code</a> by Andras Serfozo </li>
+						<li> <a href="https://engineering.wingify.com/posts/js13k-game-development/#twisty-polyhedra">Twisty Polyhedra</a> by Aditya Mishra </li>
+						<li> <a href="https://engineering.wingify.com/posts/js13k-game-development/#keep-alive">Keep-Alive</a> by Surbhi Mahajan </li>
+						<li> <a href="https://engineering.wingify.com/posts/js13k-game-development/#anti_virus">Anti_Virus</a> by Punit Gupta </li>
+						<li> <a href="https://engineering.wingify.com/posts/js13k-game-development/#sum-it-up">Sum It Up</a> by Hemkaran Raghav </li>
+						<li> <a href="https://engineering.wingify.com/posts/js13k-game-development/#up--down">Up &amp; Down</a> by Dinkar Pundir </li>
+						<li> <a href="https://engineering.wingify.com/posts/js13k-game-development/#robo-galactic-shooter">Robo Galactic Shooter</a> by Ashish Bardhan </li>
+						<li> <a href="https://xem.github.io/articles/js13k18.html">Geoquiz2 / Envelope / Man on Wire</a> by xem & friends </li>
+						<li> <a href="https://archiewald.github.io/blog/1ppm/2018/10/09/js13k-my-first-game.html"> KickIt!</a> by archiewald </li>
+						<li> <a href="https://blog.slashie.net/2018/10/18/postmortem-archerfire-duet-of-aces-js13k-2018/">ArcherFire: Duet of Aces</a> by Santiago Zapata </li>
+						<li> <a href="https://github.com/nrkn/js13k-2018/blob/master/README.md">Ranger Down</a> by Nik Coughlin </li>
+						<li> <a href="https://medium.com/@herebefrogs/submersible-warship-2063-a-js13kgames-2018-postmortem-380b0008dc50">SUBmersible WARship 2063</a> by Jerome Lecomte </li>
+						<li> <a href="https://github.com/chiaogu/planetfall">Planetfall</a> by Ian Chiao </li>
+					</ul>
+				</li>
+				<li> <a href="https://blog.github.com/2018-10-05-js13kgames-highlights-2018/">13 Games in ≤ 13kB of JavaScript</a> - GitHub's highlights by Lee Reilly </li>
+				<li> <a href="https://www.kotaku.com.au/2018/10/all-these-amazing-browser-games-take-up-13-kilobytes-or-less/">These amazing browser games are 13 kilobytes or less in size</a> by Logan Booker at Kotaku.com.au </li>
+				<li> <a href="https://thenewstack.io/tiny-javascript-games-from-the-js13kgames-competition/">Tiny JavaScript games from the JS13kGames competition</a> by David Cassel at The New Stack </li>
+				<li> <a href="https://github.blog/2019-08-07-eighth-annual-js13kgames-challenge/">Eighth annual js13kGames challenge</a> by Lee Reilly on GitHub's blog </li>
+				<li> <a href="https://ebaytech.berlin/js13kgames-a-review-c10cbe9a39e3/">js13kGames — a review</a> by eBay Tech </li>
+				<li> <a href="https://www.vice.com/en_us/article/43k453/this-real-time-strategy-game-is-just-13-kilobytes">This Real Time Strategy Game Is Just 13 Kilobytes</a> by Karl Bode at Vice Games </li>
+				<li> <a href="https://github.blog/2019-10-08-js13k-2019-highlights/">Highlights from the js13kGames 2019 competition</a> - top 10 winners showcased by Lee Reilly on GitHub's blog </li>
+				<li class="posts" id="posts2019"> <strong>2019 post-mortems:</strong>
+					<ul>
+						<li> <a href="https://unboring.net/cases/progressive-webxr-game/">Making a Progressive WebXR game with 13Kb + three.js</a> by Arturo Paracuellos </li>
+						<li> <a href="https://github.com/vonloxx/js13k-2019/blob/master/README.md">Back To The Stars</a> by Marco Fernandes </li>
+						<li> <a href="https://auroriax.com/js13kgames-back-to-the-basics/">BackFlipped: Back to the Basics</a> by Tom Hermans (@Auroriax) </li>
+						<li> <a href="https://medium.com/@niklas.b3rg/game-dev-postmortem-backstabber-hero-part-1-80c7def92c74">Backstabber Hero (Part 1 - Sources of inspiration)</a> by Niklas Berg (@nkholski) </li>
+						<li> <a href="http://xem.github.io/articles/js13k19.html">Back on Track (mania)</a> by xem </li>
+						<li> <a href="https://dev.to/mrlopis/how-to-design-a-javascript-game-in-13kb-or-less-59kn">How to design a javascript game? (in 13KB or less)</a> by Joao Lopes (@mrlopis) </li>
+						<li> <a href="https://github.com/DennisBengs/retrohaunt/tree/master/postmortem">Retrohaunt</a> by Donitz </li>
+						<li> <a href="https://medium.com/@alexc73/i-made-a-video-game-on-my-journey-to-work-8e1bf2dfd208">Back from Kooky Island</a> by Alexander Curtis </li>
+						<li> <a href="https://dev.to/mrlopis/creating-a-13kb-js-game-using-svg-5fjk">Creating a 13KB JS Game using SVG</a> by Joao Lopes (@mrlopis) </li>
+						<li> <a href="https://medium.com/@etchells.kevin/js13k-games-2019-entry-get-back-from-robot-city-22a48afe5fe">Get Back From Robot City</a> by Kev Etchells </li>
+						<li> <a href="https://github.com/picosonic/js13k-2019/blob/master/devdiary/diary.md">BACKSPACE - Return to planet Figadore</a> by picosonic (Jasper Renow-Clarke) (@femtosonic) </li>
+						<li> <a href="https://github.com/amolinasalazar/LightsBackOn/blob/master/README.md">Lights Back On</a> by Alejandro Molina (@amolinasalazar) </li>
+						<li> <a href="https://carelesslabs.wordpress.com/2019/09/19/js13k-game-jam-post-mortom-gamedev-js13k">Quick Wins</a> by Ryan Tyler ( <a href="https://twitter.com/CarelessLabs">@Carelesslabs</a>) </li>
+						<li> <a href="https://vertfromage.github.io./update/2019/09/19/entering-JS13KGames-2019-beginner.html">Backside Ball - Entering JS13KGames 2019 as a Beginner</a> by Vertfromage </li>
+						<li> <a href="https://blog.slashie.net/2019/09/22/backpack-monsters-js13k-2019/">Backpack Monsters</a> by @slashie_ </li>
+						<li> <a href="https://phoboslab.org/log/2019/09/voidcall-making-of">The Making of VOIDCAL</a> by Dominic Szablewski </li>
+						<li> <a href="https://github.com/jaammees/racer/blob/master/README.md">Racer</a> by James </li>
+						<li> <a href="https://dev.to/johnkilmister/random-learnings-from-entering-js13k-games-2019-4pcn">Random Learnings from Entering JS13K Games 2019</a> by <a href="https://twitter.com/JohnKilmister">@JohnKilmister</a> </li>
+						<li> <a href="https://64mega.github.io/js13k-2019-recap.html">JS13k 2019 Developer Commentary</a> by Daniel Lawrence ( <a href="https://twitter.com/64Mega">@64Mega</a>) </li>
+						<li> <a href="https://dev.to/salvan13/backshot-tactics-a-multiplayer-game-for-js13kgames-47ie">Backshot Tactics - A Multiplayer Game for js13kGames</a> by Antonio Salvati ( <a href="https://twitter.com/salvan13">@salvan13</a>) </li>
+						<li> <a href="https://medium.com/@mateusz.tomczyk/a-story-of-making-a-13-kb-game-in-30-days-the-wandering-wraith-post-mortem-9847c8992f49">A story of making a 13 kB game in 30 days. “The Wandering Wraith” post mortem.</a> by Mateusz Tomczyk </li>
+						<li> <a href="https://serpent7776.itch.io/back-to-life/devlog/100709/back-to-life-postmortem">Back to life</a> by <a href="https://twitter.com/serpent7776">Serpent7776</a> </li>
+						<li> <a href="https://medium.com/@herebefrogs/dont-look-back-a-js13kgames-2019-postmortem-a0028d8acef2">Do Not Look Back!</a> by <a href="https://twitter.com/herebefrogs">Jerome Lecomte</a> </li>
+						<li> <a href="https://www.deadpix3l.com/bubbas-back-room-postmortem">Bubba's Back Room</a> by <a href="https://twitter.com/ericdrowell">Eric Rowell</a> </li>
+						<li> <a href="http://frankforce.com/?p=6936">Bounce Back Postmortem: A Boomerang Adventure</a> by <a href="https://twitter.com/KilledByAPixel">Frank Force</a> </li>
+						<li> <a href="https://piesku.com/backcountry">Backcountry</a> by Michał Budzyński and Staś Małolepszy </li>
+					</ul>
+				</li>
+			</ul>
+			<a class="fork page" href="https://github.com/js13kgames/resources" title="Fork me on GitHub"></a>
+			<p class="note"> The first version of this list was originally <a href="https://gist.github.com/blueboxes/9818da26141a854cba52">created</a> by <a href="https://github.com/blueboxes">John Kilmister</a>. </p>
+		</main>
+		<footer>
+			<div> &copy; js13kGames 2012-2019
+				<p>Created and maintained by <a target="_blank" href="https://end3r.com">Andrzej Mazur</a> from <a target="_blank" href="https://enclavegames.com">Enclave Games</a>. </p>
+			</div>
+		</footer>
+	</body>
 </html>


### PR DESCRIPTION
This PR adds an `npm` version of @mtmckenna's [js13k-webpack-typescript-starter-party](https://github.com/mtmckenna/js13k-webpack-typescript-starter-party).

This PR also corrects some HTML issues that were present within the document.