### PR TITLE
Add link to 2021 post-mortem list

### DIFF
--- a/index.html
+++ b/index.html
@@ -420,6 +420,7 @@
 			<ul>
 				<li><a href="https://github.com/picosonic/js13k-2021-mobile/blob/main/devdiary/diary.md">Crater Space</a> by picosonic (Jasper Renow-Clarke) <a href="https://twitter.com/femtosonic">@femtosonic</a></li>
 				<li><a href="https://github.com/picosonic/js13k-2021/blob/main/devdiary/diary.md">Airspace Alpha Zulu</a> by picosonic (Jasper Renow-Clarke) <a href="https://twitter.com/femtosonic">@femtosonic</a></li>
+				<li><a href="https://github.com/elliot-nelson/js13k-2021-keening-star/blob/main/README.md#post-mortem">Shadow of the Keening Star</a> by Elliot Nelson <a href="https://twitter.com/7tonshark">@7tonshark</a></li>
 			</ul>
 		</li>
 	</ul>


### PR DESCRIPTION
### SUMMARY

Add "Shadow of the Keening Star" to the 2021 post-mortem list.